### PR TITLE
Set all fields as schema

### DIFF
--- a/season_pass/api/user.py
+++ b/season_pass/api/user.py
@@ -79,4 +79,8 @@ def claim_reward(request: ClaimRequestSchema, sess=Depends(session)):
     sess.refresh(user_season)
 
     # Return result
-    return ClaimResultSchema(items=reward_items, currencies=reward_currencies, user=user_season)
+    return ClaimResultSchema(
+        items=[{"item_id": k, "amount": v} for k, v in reward_items.items()],
+        currencies=[{"ticker": k, "amount": v} for k, v in reward_currencies.items()],
+        user=user_season
+    )

--- a/season_pass/schemas/season_pass.py
+++ b/season_pass/schemas/season_pass.py
@@ -4,6 +4,27 @@ from typing import List
 from pydantic import BaseModel as BaseSchema
 
 
+class ItemInfoSchema(BaseSchema):
+    item_id: int
+    amount: int
+
+
+class CurrencyInfoSchema(BaseSchema):
+    ticker: str
+    amount: float
+
+
+class RewardDetailSchema(BaseSchema):
+    item: List[ItemInfoSchema]
+    currency: List[CurrencyInfoSchema]
+
+
+class RewardSchema(BaseSchema):
+    level: int
+    normal: RewardDetailSchema
+    premium: RewardDetailSchema
+
+
 class SeasonPassSchema(BaseSchema):
     id: int
     start_date: date

--- a/season_pass/schemas/user.py
+++ b/season_pass/schemas/user.py
@@ -1,6 +1,8 @@
-from typing import Dict
+from typing import List
 
 from pydantic import BaseModel as BaseSchema
+
+from season_pass.schemas.season_pass import ItemInfoSchema, CurrencyInfoSchema
 
 
 class UserSeasonPassSchema(BaseSchema):
@@ -24,6 +26,6 @@ class ClaimRequestSchema(BaseSchema):
 
 
 class ClaimResultSchema(BaseSchema):
-    items: Dict[int, int]
-    currencies: Dict[str, float]
+    items: List[ItemInfoSchema]
+    currencies: List[CurrencyInfoSchema]
     user: UserSeasonPassSchema


### PR DESCRIPTION
Set all fields inside pydantic scahems as schema, not typing class.
This is for compatibility with client.