### PR TITLE
Bugfix/authorization

### DIFF
--- a/season_pass/settings/__init__.py
+++ b/season_pass/settings/__init__.py
@@ -31,7 +31,7 @@ DB_ECHO = config("DB_ECHO", cast=bool, default=False)
 try:
     JWT_TOKEN_SECRET = fetch_parameter(region=os.environ.get("REGION_NAME"),
                                        parameter_name=f"{os.environ.get('STAGE')}_9c_SEASON_PASS_JWT_TOKEN_SECRET",
-                                       secure=True)
+                                       secure=True)["Value"]
 except:
     pass
 

--- a/season_pass/utils.py
+++ b/season_pass/utils.py
@@ -56,9 +56,9 @@ def verify_token(authorization: Annotated[str, Header()]):
         if ((datetime.utcfromtimestamp(token_data["iat"]) + timedelta(hours=1))
                 < datetime.utcfromtimestamp(token_data["exp"])):
             raise ExpiredSignatureError("Too long token lifetime")
-        if datetime.utcfromtimestamp(token_data["iat"]) > now:
+        if datetime.utcfromtimestamp(token_data["iat"]).astimezone(timezone.utc) > now:
             raise ExpiredSignatureError("Invalid token issue timestamp")
-        if datetime.utcfromtimestamp(token_data["exp"]) < now:
+        if datetime.utcfromtimestamp(token_data["exp"]).astimezone(timezone.utc) < now:
             raise ExpiredSignatureError("Token expired")
 
     except Exception as e:


### PR DESCRIPTION
- Use parameter value, not whole response
- Use timezone aware datetime