### PR TITLE
Feature/claim all items

### DIFF
--- a/common/utils/_graphql.py
+++ b/common/utils/_graphql.py
@@ -94,10 +94,10 @@ class GQL:
     def _claim_items(self, pubkey: bytes, nonce: int, **kwargs) -> bytes:
         ts = kwargs.get("timestamp", datetime.datetime.utcnow().isoformat())
         avatar_addr: str = kwargs.get("avatar_addr")
-        claim_items: List[Dict[str, Any]] = kwargs.get("claim_items")
+        claim_data: List[Dict[str, Any]] = kwargs.get("claim_data")
         memo = kwargs.get("memo")
 
-        if not claim_items:
+        if not claim_data:
             raise ValueError("Nothing to claim")
 
         query = dsl_gql(
@@ -112,7 +112,7 @@ class GQL:
                             "avatarAddress": avatar_addr,
                             "fungibleAssetValues": [{"ticker": x["ticker"], "quantity": x["amount"],
                                                      "decimalPlaces": x.get("decimal_places", 0), "minters": []}
-                                                    for x in claim_items],
+                                                    for x in claim_data],
                             "memo": memo
                         }]
                     )

--- a/common/utils/_graphql.py
+++ b/common/utils/_graphql.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import os
-from typing import Union, Dict, Any, Tuple, Optional
+from typing import Union, Dict, Any, Tuple, Optional, List
 
 import requests
 from gql import Client
@@ -94,7 +94,8 @@ class GQL:
     def _claim_items(self, pubkey: bytes, nonce: int, **kwargs) -> bytes:
         ts = kwargs.get("timestamp", datetime.datetime.utcnow().isoformat())
         avatar_addr: str = kwargs.get("avatar_addr")
-        claim_items: Dict[Dict[str, int]] = kwargs.get("claim_items")
+        claim_items: List[Dict[str, Any]] = kwargs.get("claim_items")
+        memo = kwargs.get("memo")
 
         if not claim_items:
             raise ValueError("Nothing to claim")
@@ -109,8 +110,10 @@ class GQL:
                     self.ds.ActionTxQuery.claimItems.args(
                         claimData=[{
                             "avatarAddress": avatar_addr,
-                            "fungibleAssetValues": [{"ticker": k, "quantity": v, "decimalPlaces": 0, "minters": []}
-                                                    for k, v in claim_items.items()]
+                            "fungibleAssetValues": [{"ticker": x["ticker"], "quantity": x["amount"],
+                                                     "decimalPlaces": x.get("decimal_places", 0), "minters": []}
+                                                    for x in claim_items],
+                            "memo": memo
                         }]
                     )
                 )

--- a/scripts/fetch_reward.py
+++ b/scripts/fetch_reward.py
@@ -1,6 +1,9 @@
+import json
 import logging
+import os
 import sys
-from typing import List
+from datetime import datetime
+from typing import List, Tuple
 
 from scripts.google import Spreadsheet
 
@@ -12,37 +15,50 @@ def fetch(credential_file: str, sheet_id: str):
     return data["values"]
 
 
-def to_json(data: List):
+def to_ticker(item_id: str | int) -> Tuple[str, int]:
+    """
+    Create ticker from item ID and returns with decimal places.
+    """
+    DECIMAL_DICT = {
+        "CRYSTAL": 18,
+    }
+    if item_id.upper() in ("CRYSTAL",):
+        return f"FAV__{item_id.upper()}", DECIMAL_DICT.get(item_id.upper(), 0)
+    else:
+        return f"Item_NT_{item_id}", 0
+
+
+def to_json(data: List) -> str:
     reward_list = []
     head, *body = data
     for b in body:
-        data = {"level": int(b[0]), "normal": {"item": [], "currency": []}, "premium": {"item": [], "currency": []}}
-
-        if b[1] == "crystal":
-            data["normal"]["currency"].append({"ticker": "CRYSTAL", "amount": int(b[2].replace(",", ""))})
-        else:
-            data["normal"]["item"].append({"id": int(b[1]), "amount": int(b[2].replace(",", ""))})
+        data = {"level": int(b[0]), "normal": [], "premium": []}
+        ticker, decimal_places = to_ticker(b[1])
+        data["normal"].append(
+            {"ticker": ticker, "amount": int(b[2].replace(",", "")), "decimal_places": decimal_places})
 
         if len(b) > 3 and b[3]:
-            if b[3] == "crystal":
-                data["premium"]["currency"].append({"ticker": "CRYSTAL", "amount": int(b[4].replace(",", ""))})
-            else:
-                data["premium"]["item"].append({"id": int(b[3]), "amount": int(b[4].replace(",", ""))})
+            ticker, decimal_places = to_ticker(b[3])
+            data["premium"].append(
+                {"ticker": ticker, "amount": int(b[4].replace(",", "")), "decimal_places": decimal_places})
 
         if len(b) > 5 and b[5]:
-            if b[5] == "crystal":
-                data["premium"]["currency"].append({"ticker": "CRYSTAL", "amount": int(b[6].replace(",", ""))})
-            else:
-                data["premium"]["item"].append({"id": int(b[5]), "amount": int(b[6].replace(",", ""))})
+            ticker, decimal_places = to_ticker(b[5])
+            data["premium"].append(
+                {"ticker": ticker, "amount": int(b[6].replace(",", "")), "decimal_places": decimal_places})
 
         reward_list.append(data)
-    return reward_list
+    return json.dumps(reward_list)
 
 
 def main(credential_file: str, sheet_id: str):
+    if not os.path.exists("data"):
+        os.mkdir("data")
     data = fetch(credential_file, sheet_id)
     reward_list = to_json(data)
     print(reward_list)
+    with open(f"data/season_pass_reward_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json", "w") as f:
+        f.write(reward_list)
     return reward_list
 
 

--- a/season_pass/api/__init__.py
+++ b/season_pass/api/__init__.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter
+
+from season_pass import settings
 from season_pass.api import season_pass, user, tmp
 
 router = APIRouter(
@@ -9,8 +11,10 @@ router = APIRouter(
 __all__ = [
     season_pass,
     user,
-    tmp,
 ]
+
+if settings.stage != "mainnet":
+    __all__.append(tmp)
 
 for view in __all__:
     router.include_router(view.router)

--- a/season_pass/api/user.py
+++ b/season_pass/api/user.py
@@ -114,8 +114,8 @@ def upgrade_season_pass(request: UpgradeRequestSchema, sess=Depends(session)):
             planet_id=request.planet_id,
             agent_addr=request.agent_addr,
             avatar_addr=request.avatar_addr,
-            reward_list=[{"ticker": x.id, "amount": x.amount, "decimal_places": x.get("decimal_places", 0)}
-                         for x in request.reward_list.claims],
+            reward_list=[{"ticker": x.ticker, "amount": x.amount, "decimal_places": x.decimal_places}
+                         for x in request.reward_list],
         )
         resp = sqs.send_message(QueueUrl=settings.SQS_URL, MessageBody=json.dumps({"uuid": claim.uuid}))
         logging.debug(f"Message [{resp['MessageId']}] sent to SQS")

--- a/season_pass/api/user.py
+++ b/season_pass/api/user.py
@@ -114,7 +114,8 @@ def upgrade_season_pass(request: UpgradeRequestSchema, sess=Depends(session)):
             planet_id=request.planet_id,
             agent_addr=request.agent_addr,
             avatar_addr=request.avatar_addr,
-            reward_list={"claim": {x.id: x.amount for x in request.reward_list.claims}},
+            reward_list=[{"ticker": x.id, "amount": x.amount, "decimal_places": x.get("decimal_places", 0)}
+                         for x in request.reward_list.claims],
         )
         resp = sqs.send_message(QueueUrl=settings.SQS_URL, MessageBody=json.dumps({"uuid": claim.uuid}))
         logging.debug(f"Message [{resp['MessageId']}] sent to SQS")

--- a/season_pass/main.py
+++ b/season_pass/main.py
@@ -7,9 +7,11 @@ __VERSION__ = "0.0.1"
 
 from mangum import Mangum
 from starlette.requests import Request
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, JSONResponse
+from starlette.status import HTTP_404_NOT_FOUND
 
 from common import logger
+from season_pass.exceptions import SeasonNotFoundError, UserNotFoundError
 from season_pass import settings, api
 
 stage = os.environ.get("STAGE", "local")
@@ -27,6 +29,21 @@ app = FastAPI(
 def log_incoming_url(request: Request, call_next):
     logger.info(f"[{request.method}] {request.url}")
     return call_next(request)
+
+
+def handle_404(err: str):
+    logger.error(err)
+    return JSONResponse(status_code=HTTP_404_NOT_FOUND, content=err)
+
+
+@app.exception_handler(SeasonNotFoundError)
+def handle_season_not_found(request: Request, e: SeasonNotFoundError):
+    return handle_404(str(e))
+
+
+@app.exception_handler(UserNotFoundError)
+def handle_user_not_found(request: Request, e: UserNotFoundError):
+    return handle_404(str(e))
 
 
 @app.get("/ping", tags=["Default"])

--- a/season_pass/schemas/season_pass.py
+++ b/season_pass/schemas/season_pass.py
@@ -1,7 +1,7 @@
 from datetime import date
-from typing import List
+from typing import List, Optional
 
-from pydantic import BaseModel as BaseSchema
+from pydantic import BaseModel as BaseSchema, model_validator
 
 from common.enums import ActionType
 
@@ -16,15 +16,23 @@ class CurrencyInfoSchema(BaseSchema):
     amount: float
 
 
-class RewardDetailSchema(BaseSchema):
-    item: List[ItemInfoSchema]
-    currency: List[CurrencyInfoSchema]
+class ClaimSchema(BaseSchema):
+    ticker: str
+    amount: int
+    decimal_places: int = 0
+    id: Optional[str] = ""
+
+    # Compatibility
+    @model_validator(mode="after")
+    def _id(self):
+        self.id = self.ticker.split("_")[-1]
+        return self
 
 
 class RewardSchema(BaseSchema):
     level: int
-    normal: RewardDetailSchema
-    premium: RewardDetailSchema
+    normal: List[ClaimSchema]
+    premium: List[ClaimSchema]
 
 
 class SeasonPassSchema(BaseSchema):

--- a/season_pass/schemas/user.py
+++ b/season_pass/schemas/user.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel as BaseSchema, model_validator
+from pydantic import BaseModel as BaseSchema, model_validator, Field
 
 from common.enums import PlanetID
 from season_pass.schemas.season_pass import ItemInfoSchema, CurrencyInfoSchema
@@ -29,25 +29,10 @@ class UserSeasonPassSchema(BaseSchema):
         from_attributes = True
 
 
-class RewardItemSchema(BaseSchema):
-    id: int
-    amount: int
-
-
-class RewardCurrencySchema(BaseSchema):
-    ticker: str
-    amount: str
-
-
 class ClaimSchema(BaseSchema):
     id: str
     amount: int
-
-
-class UpgradeRewardSchema(BaseSchema):
-    items: List[RewardItemSchema] = []
-    currencies: List[RewardCurrencySchema] = []
-    claims: List[ClaimSchema] = []
+    decimal_places: int = 0
 
 
 class UpgradeRequestSchema(BaseSchema):
@@ -59,7 +44,7 @@ class UpgradeRequestSchema(BaseSchema):
     is_premium_plus: bool = False
     g_sku: str
     a_sku: str
-    reward_list: UpgradeRewardSchema = None
+    reward_list: List[ClaimSchema] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def sanitize(self):

--- a/season_pass/schemas/user.py
+++ b/season_pass/schemas/user.py
@@ -3,7 +3,7 @@ from typing import List
 from pydantic import BaseModel as BaseSchema, model_validator, Field
 
 from common.enums import PlanetID
-from season_pass.schemas.season_pass import ItemInfoSchema, CurrencyInfoSchema
+from season_pass.schemas.season_pass import ItemInfoSchema, CurrencyInfoSchema, ClaimSchema
 from season_pass.settings import stage
 
 
@@ -27,12 +27,6 @@ class UserSeasonPassSchema(BaseSchema):
 
     class Config:
         from_attributes = True
-
-
-class ClaimSchema(BaseSchema):
-    id: str
-    amount: int
-    decimal_places: int = 0
 
 
 class UpgradeRequestSchema(BaseSchema):

--- a/season_pass/schemas/user.py
+++ b/season_pass/schemas/user.py
@@ -77,6 +77,8 @@ class ClaimRequestSchema(BaseSchema):
 
 
 class ClaimResultSchema(BaseSchema):
+    reward_list: List[ClaimSchema] = []
+    user: UserSeasonPassSchema
+    # Deprecated: For backward compatibility
     items: List[ItemInfoSchema]
     currencies: List[CurrencyInfoSchema]
-    user: UserSeasonPassSchema

--- a/season_pass/settings/__init__.py
+++ b/season_pass/settings/__init__.py
@@ -33,7 +33,7 @@ try:
                                        parameter_name=f"{os.environ.get('STAGE')}_9c_SEASON_PASS_JWT_TOKEN_SECRET",
                                        secure=True)["Value"]
 except:
-    pass
+    JWT_TOKEN_SECRET = config("JWT_TOKEN_SECRET")
 
 # AWS
 REGION_NAME = config("REGION_NAME")

--- a/season_pass/utils.py
+++ b/season_pass/utils.py
@@ -53,12 +53,12 @@ def verify_token(authorization: Annotated[str, Header()]):
         if prefix != "Bearer":
             raise Exception("Invalid token type. Use `Bearer [TOKEN]`.")
         token_data = jwt.decode(body, settings.JWT_TOKEN_SECRET, audience="SeasonPass", algorithms=["HS256"])
-        if ((datetime.utcfromtimestamp(token_data["iat"]) + timedelta(hours=1))
-                < datetime.utcfromtimestamp(token_data["exp"])):
+        if ((datetime.fromtimestamp(token_data["iat"], tz=timezone.utc) + timedelta(hours=1))
+                < datetime.fromtimestamp(token_data["exp"], tz=timezone.utc)):
             raise ExpiredSignatureError("Too long token lifetime")
-        if datetime.utcfromtimestamp(token_data["iat"]).astimezone(timezone.utc) > now:
+        if datetime.fromtimestamp(token_data["iat"], tz=timezone.utc) > now:
             raise ExpiredSignatureError("Invalid token issue timestamp")
-        if datetime.utcfromtimestamp(token_data["exp"]).astimezone(timezone.utc) < now:
+        if datetime.fromtimestamp(token_data["exp"], tz=timezone.utc) < now:
             raise ExpiredSignatureError("Token expired")
 
     except Exception as e:

--- a/worker/unloader.py
+++ b/worker/unloader.py
@@ -58,8 +58,7 @@ def handle(event, context):
             unsigned_tx = gql.create_action(
                 claim.planet_id,
                 "claim_items", pubkey=account.pubkey, nonce=nonce,
-                avatar_addr=claim.avatar_addr,
-                claim_items=claim.reward_list,
+                avatar_addr=claim.avatar_addr, claim_data=claim.reward_list,
                 memo=json.dumps({"season_pass": {"n": claim.normal_levels, "p": claim.premium_levels, "t": "claim"}}),
             )
             signature = account.sign_tx(unsigned_tx)

--- a/worker/unloader.py
+++ b/worker/unloader.py
@@ -1,7 +1,6 @@
 # Receive message from SQS and send season pass reward
 import json
 import os
-from datetime import timezone, datetime, timedelta
 
 from sqlalchemy import create_engine, select, desc
 from sqlalchemy.orm import sessionmaker, scoped_session
@@ -9,11 +8,10 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from common import logger
 from common.enums import TxStatus
 from common.models.user import Claim
-from common.utils.aws import fetch_secrets, fetch_kms_key_id
-from consts import ITEM_FUNGIBLE_ID_DICT
-from schemas.sqs import SQSMessage
 from common.utils._crypto import Account
 from common.utils._graphql import GQL
+from common.utils.aws import fetch_secrets, fetch_kms_key_id
+from schemas.sqs import SQSMessage
 
 DB_URI = os.environ.get("DB_URI")
 db_password = fetch_secrets(os.environ.get("REGION_NAME"), os.environ.get("SECRET_ARN"))["password"]
@@ -57,30 +55,13 @@ def handle(event, context):
 
             claim.nonce = nonce
             claim.tx_status = TxStatus.CREATED
-            if "claim" in claim.reward_list:
-                unsigned_tx = gql.create_action(
-                    claim.planet_id,
-                    "claim_items", pubkey=account.pubkey, nonce=nonce,
-                    avatar_addr=claim.avatar_addr,
-                    claim_items=claim.reward_list["claim"],
-                )
-            else:
-                unsigned_tx = gql.create_action(
-                    claim.planet_id,
-                    "unload_from_garage", pubkey=account.pubkey, nonce=nonce,
-                    avatar_addr=claim.avatar_addr,
-                    fav_data=[{
-                        "balanceAddr": claim.agent_addr,
-                        "value": {"currencyTicker": ticker, "value": f"{amount}"}
-                    } for ticker, amount in claim.reward_list["currency"].items()],
-                    item_data=[{
-                        "fungibleId": ITEM_FUNGIBLE_ID_DICT[item_id],
-                        "count": f"{amount}"
-                    } for item_id, amount in claim.reward_list["item"].items()],
-                    timestamp=(datetime.now(tz=timezone.utc) + timedelta(days=1)).isoformat(),
-                    memo=json.dumps({"season_pass": {"n": claim.normal_levels, "p": claim.premium_levels,
-                                                     "t": "claim"}}),
-                )
+            unsigned_tx = gql.create_action(
+                claim.planet_id,
+                "claim_items", pubkey=account.pubkey, nonce=nonce,
+                avatar_addr=claim.avatar_addr,
+                claim_items=claim.reward_list,
+                memo=json.dumps({"season_pass": {"n": claim.normal_levels, "p": claim.premium_levels, "t": "claim"}}),
+            )
             signature = account.sign_tx(unsigned_tx)
             signed_tx = gql.sign(claim.planet_id, unsigned_tx, signature)
             claim.tx = signed_tx.hex()

--- a/worker/worker_cdk_stack.py
+++ b/worker/worker_cdk_stack.py
@@ -64,6 +64,15 @@ class WorkerStack(Stack):
                 _iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaVPCAccessExecutionRole"),
             ],
         )
+        # This is just for stack compatibility
+        unloader_role.add_to_policy(
+            _iam.PolicyStatement(
+                actions=["sqs:sendmessage"],
+                resources=[
+                    self.shared_stack.brave_q.queue_arn,
+                ]
+            )
+        )
         unloader_role = self.__add_policy(unloader_role, db_password=True, kms=True)
         unloader = _lambda.Function(
             self, f"{self.config.stage}-9c-season_pass-unloader-function",


### PR DESCRIPTION
- SeasonPass only uses `ClaimItems` action
- Update model/schema to remove reward section "item" and "currency"
    - All the reward types are treated as FAV.
- Apply new schema
    - GQL uses data from new schema
    - Unloaderr uses new schema
    - season pass upgrade API uses new schema