### PR TITLE
Use custom AMI for block tracker instance

### DIFF
--- a/worker/worker_cdk_stack.py
+++ b/worker/worker_cdk_stack.py
@@ -47,8 +47,8 @@ class WorkerStack(Stack):
             )
         else:
             instance_type = _ec2.InstanceType.of(_ec2.InstanceClass.BURSTABLE4_GRAVITON, _ec2.InstanceSize.SMALL)
-            ami = _ec2.MachineImage.from_ssm_parameter(
-                "/aws/service/canonical/ubuntu/server/jammy/stable/current/arm64/hvm/ebs-gp2/ami-id"
+            ami = _ec2.MachineImage.lookup(
+                name="mainnet_9c_season-pass_block_tracker-20231219",
             )
 
         block_tracker = _ec2.Instance(

--- a/worker/worker_cdk_stack.py
+++ b/worker/worker_cdk_stack.py
@@ -40,15 +40,20 @@ class WorkerStack(Stack):
         self.shared_stack.brave_q.grant_send_messages(tracker_role)
         self.__add_policy(tracker_role, db_password=True)
 
-        if self.config.stage == "internal":
+        if self.config.stage == "mainnet":
             instance_type = _ec2.InstanceType.of(_ec2.InstanceClass.M6G, _ec2.InstanceSize.LARGE)
+            ami = _ec2.MachineImage.lookup(
+                name="mainnet_9c_season-pass_block_tracker-20231219",
+            )
+        elif self.config.stage == "internal":
+            instance_type = _ec2.InstanceType.of(_ec2.InstanceClass.BURSTABLE4_GRAVITON, _ec2.InstanceSize.SMALL)
             ami = _ec2.MachineImage.lookup(
                 name="internal-9c-season_pass-block_tracker-20231209",
             )
         else:
             instance_type = _ec2.InstanceType.of(_ec2.InstanceClass.BURSTABLE4_GRAVITON, _ec2.InstanceSize.SMALL)
-            ami = _ec2.MachineImage.lookup(
-                name="mainnet_9c_season-pass_block_tracker-20231219",
+            ami = _ec2.MachineImage.from_ssm_parameter(
+                "/aws/service/canonical/ubuntu/server/jammy/stable/current/arm64/hvm/ebs-gp2/ami-id"
             )
 
         block_tracker = _ec2.Instance(


### PR DESCRIPTION
Use EC2 image with python3.11 + poetry + env + enabled service for block tracker EC2 instance.