### PR TITLE
Add enabled_planets config to selectively disable Thor in block-status

### DIFF
--- a/apps/api/app/api/__init__.py
+++ b/apps/api/app/api/__init__.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 import requests
+from app.config import config
+from app.dependencies import session
 from fastapi import APIRouter, Depends
 from shared.constants import SEASONPASS_ADDRESS
 from shared.enums import PassType, PlanetID, TxStatus
@@ -11,9 +13,6 @@ from shared.utils.season_pass import create_jwt_token
 from sqlalchemy import desc, func, or_, select
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
-
-from app.config import config
-from app.dependencies import session
 
 from . import admin, season_pass, tmp, user
 
@@ -124,7 +123,10 @@ def block_status(sess=Depends(session)):
     }
 
     thor_planet = PlanetID.THOR if stage == "mainnet" else PlanetID.THOR_INTERNAL
-    if thor_planet in config.converted_gql_url_map:
+    if (
+        thor_planet in config.converted_gql_url_map
+        and thor_planet.value.decode() in config.enabled_planets
+    ):
         thor_tip = get_tip(config.converted_gql_url_map[thor_planet])
         thor_blocks = get_db_tip(sess, thor_planet)
         result[thor_planet.name] = {

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -22,6 +22,11 @@ class Settings(BaseSettings):
         "0x000000000001": "https://heimdall-rpc.nine-chronicles.com/graphql",
         "0x000000000003": "https://thor-rpc.nine-chronicles.com/graphql",
     }
+    enabled_planets: list[str] = [
+        "0x000000000000",
+        "0x000000000001",
+        "0x000000000003",
+    ]
 
     @property
     def converted_gql_url_map(self) -> dict[PlanetID, str]:


### PR DESCRIPTION
## Summary
- `apps/api/app/config.py`에 `enabled_planets` 설정 추가 (기본값: Odin, Heimdall, Thor 전체)
- `block-status` 엔드포인트에서 Thor 처리 시 `enabled_planets` 포함 여부를 추가로 체크
- Thor를 비활성화하려면 `API_ENABLED_PLANETS=["0x000000000000","0x000000000001"]` 환경변수 설정

## Test plan
- [ ] `API_ENABLED_PLANETS=["0x000000000000","0x000000000001"]` 설정 후 `/api/block-status` 응답에 THOR 키 없음 확인
- [ ] `enabled_planets`에 Thor 포함 시 기존 동작 유지 확인
- [ ] `/api/check_nonce?planet=thor` 등 다른 엔드포인트 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)