### PR TITLE
Add reward-claims stats endpoint for monthly reward aggregation

### DIFF
--- a/apps/api/app/api/admin.py
+++ b/apps/api/app/api/admin.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from decimal import Decimal
+from typing import Dict, List, Optional
 
 from app.celery import send_to_worker
 from app.dependencies import session
@@ -8,7 +9,7 @@ from app.utils import verify_token
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from fastapi.security import HTTPBearer
 from pydantic import BaseModel
-from shared.enums import ActionType, PassType, TxStatus
+from shared.enums import ActionType, PassType, PlanetID, TxStatus
 from shared.models.season_pass import Exp, SeasonPass
 from shared.models.user import Claim, UserSeasonPass
 from shared.utils.season_pass import get_pass
@@ -600,3 +601,72 @@ def burn_asset(burn_request: BurnAssetRequest):
         raise HTTPException(
             status_code=500, detail=f"Failed to trigger burn asset task: {str(e)}"
         )
+
+
+class RewardClaimItem(BaseModel):
+    ticker: str
+    decimal_places: int
+    total_amount: Decimal
+
+
+class PlanetRewardClaims(BaseModel):
+    tokens: List[RewardClaimItem]
+
+
+class RewardClaimsResponse(BaseModel):
+    year: int
+    month: int
+    planets: Dict[str, PlanetRewardClaims]
+
+
+@router.get("/stats/reward-claims", response_model=RewardClaimsResponse)
+def get_reward_claims(
+    year: int = Query(..., ge=2020, le=2030),
+    month: int = Query(..., ge=1, le=12),
+    sess=Depends(session),
+):
+    utc_start = datetime(year, month, 1, tzinfo=timezone.utc)
+    utc_end = (
+        datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+        if month == 12
+        else datetime(year, month + 1, 1, tzinfo=timezone.utc)
+    )
+
+    mainnet_planets = [PlanetID.ODIN.value, PlanetID.HEIMDALL.value]
+
+    claims = sess.scalars(
+        select(Claim).where(
+            Claim.tx_status == TxStatus.SUCCESS,
+            Claim.planet_id.in_(mainnet_planets),
+            Claim.created_at >= utc_start,
+            Claim.created_at < utc_end,
+        )
+    ).all()
+
+    agg: dict = {}
+    for claim in claims:
+        planet_name = PlanetID(claim.planet_id).name
+        planet_agg = agg.setdefault(planet_name, {})
+        for reward in claim.reward_list:
+            ticker = reward["ticker"]
+            dp = reward.get("decimal_places", 0)
+            amount = Decimal(str(reward["amount"]))
+            if ticker not in planet_agg:
+                planet_agg[ticker] = {"decimal_places": dp, "total_amount": Decimal(0)}
+            planet_agg[ticker]["total_amount"] += amount
+
+    planets = {
+        planet: PlanetRewardClaims(
+            tokens=[
+                RewardClaimItem(
+                    ticker=t,
+                    decimal_places=v["decimal_places"],
+                    total_amount=v["total_amount"],
+                )
+                for t, v in tokens.items()
+            ]
+        )
+        for planet, tokens in agg.items()
+    }
+
+    return RewardClaimsResponse(year=year, month=month, planets=planets)


### PR DESCRIPTION
## Summary
- `GET /admin/stats/reward-claims` 엔드포인트 추가
- `year`, `month` 쿼리 파라미터로 해당 월에 시즌패스에서 실제 지급된 재화를 집계
- `tx_status == SUCCESS`인 Claim만 포함, 메인넷(ODIN, HEIMDALL) 기준, UTC 날짜 범위 필터링
- 행성별·ticker별로 그룹핑하여 총 지급량 반환

## Test plan
- [ ] `/docs`에서 JWT 토큰으로 `GET /admin/stats/reward-claims?year=2025&month=3` 호출 확인
- [ ] 인증 토큰 없이 호출 시 401 반환 확인
- [ ] DB에서 해당 월 SUCCESS Claim의 reward_list 합계와 응답값 대조

🤖 Generated with [Claude Code](https://claude.com/claude-code)