### PR TITLE
Fix hard mode sweep courage exp using actual stage CostAP

### DIFF
--- a/apps/tracker/app/consumers/courage_consumer.py
+++ b/apps/tracker/app/consumers/courage_consumer.py
@@ -4,6 +4,7 @@ import requests
 import structlog
 from app.config import config
 from app.utils.season_pass import apply_exp, verify_season_pass
+from app.utils.stage_cost import get_stage_cost_ap
 from app.utils.stake import StakeAPCoef
 from shared.enums import ActionType, PassType, PlanetID
 from shared.models.action import ActionHistory, Block
@@ -15,7 +16,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-AP_PER_ADVENTURE = 5
+DEFAULT_AP_PER_ADVENTURE = 5
 
 logger = structlog.get_logger(__name__)
 
@@ -54,7 +55,13 @@ def handle_sweep(
                 coef = ap_coef.get_ap_coef(float(data["deposit"]))
             coef_dict[d["agent_addr"]] = coef
 
-        real_count = d["count_base"] // (AP_PER_ADVENTURE * coef / 100)
+        stage_id = d.get("stage_id")
+        cost_ap = (
+            get_stage_cost_ap(planet_id, stage_id)
+            if stage_id
+            else DEFAULT_AP_PER_ADVENTURE
+        )
+        real_count = d["count_base"] // (cost_ap * coef / 100)
 
         if exp * real_count < 0:
             logger.warning(

--- a/apps/tracker/app/trackers/courage_tracker.py
+++ b/apps/tracker/app/trackers/courage_tracker.py
@@ -1,10 +1,12 @@
-import concurrent.futures
 import json
-import time
 from collections import defaultdict
 
 import jwt
 import structlog
+from app.config import config
+from app.consumers.courage_consumer import consume_courage_message
+from app.schemas.action import ActionJson
+from app.utils.gql import fetch_block_data, get_block_tip
 from shared.enums import PassType
 from shared.models.action import Block
 from shared.models.arena import BattleHistory
@@ -12,12 +14,6 @@ from shared.schemas.message import TrackerMessage
 from sqlalchemy import create_engine, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import scoped_session, sessionmaker
-
-from app.celery import send_to_worker
-from app.config import config
-from app.consumers.courage_consumer import consume_courage_message
-from app.schemas.action import ActionJson
-from app.utils.gql import fetch_block_data, get_block_tip
 
 logger = structlog.get_logger(__name__)
 engine = create_engine(str(config.pg_dsn))
@@ -90,14 +86,15 @@ def track_courage_actions(planet_id: str, gql_url: str, block_index: int):
                 finally:
                     sess.close()
 
-            action_data[action_json.type_id].append(
-                {
-                    "tx_id": tx["id"],
-                    "agent_addr": tx["signer"].lower(),
-                    "avatar_addr": action_json.avatar_addr.lower(),
-                    "count_base": action_json.count_base,
-                }
-            )
+            entry = {
+                "tx_id": tx["id"],
+                "agent_addr": tx["signer"].lower(),
+                "avatar_addr": action_json.avatar_addr.lower(),
+                "count_base": action_json.count_base,
+            }
+            if action_json.stageId is not None:
+                entry["stage_id"] = action_json.stageId
+            action_data[action_json.type_id].append(entry)
 
     logger.info(
         f"Sending task to Celery worker: season_pass.process_courage",
@@ -121,25 +118,27 @@ def track_missing_blocks():
         sess = scoped_session(sessionmaker(bind=engine))
         try:
             current_tip = get_block_tip(gql_url, config.headless_jwt_secret)
-            
+
             existing_block = sess.scalar(
                 select(Block).where(
                     Block.planet_id == planet_id.encode(),
                     Block.pass_type == PassType.COURAGE_PASS,
                 )
             )
-            
+
             if not existing_block:
-                raise ValueError(f"No existing block found for planet {planet_id} and pass type {PassType.COURAGE_PASS}")
-            
+                raise ValueError(
+                    f"No existing block found for planet {planet_id} and pass type {PassType.COURAGE_PASS}"
+                )
+
             start_from = existing_block.last_processed_index + 1
-            
+
             if start_from >= current_tip:
                 logger.info(
                     f"Planet {planet_id}: Already up to date. Current tip: {current_tip}"
                 )
                 continue
-                
+
             logger.info(
                 f"Processing blocks from {start_from} to {current_tip}",
                 tracker="courage_tracker",
@@ -147,14 +146,14 @@ def track_missing_blocks():
                 start_block=start_from,
                 end_block=current_tip,
             )
-            
+
             # Process blocks in batches of 100
             end_block = min(start_from + 100, current_tip)
-            
+
             for block_index in range(start_from, end_block):
                 try:
                     track_courage_actions(planet_id, gql_url, block_index)
-                    
+
                     if existing_block:
                         existing_block.last_processed_index = block_index
                     else:
@@ -164,10 +163,10 @@ def track_missing_blocks():
                             last_processed_index=block_index,
                         )
                         sess.add(existing_block)
-                    
+
                     sess.commit()
                     logger.info(f"Block {block_index} processed successfully")
-                    
+
                 except Exception as e:
                     sess.rollback()
                     logger.exception(
@@ -175,13 +174,13 @@ def track_missing_blocks():
                         exc=e,
                     )
                     break
-            
+
             logger.info(
                 f"Processed blocks from {start_from} to {end_block}",
                 tracker="courage_tracker",
                 planet_id=planet_id,
             )
-                    
+
         except Exception as e:
             logger.exception(
                 f"Error in track_missing_blocks for planet {planet_id}",

--- a/apps/tracker/app/trackers/courage_tracker.py
+++ b/apps/tracker/app/trackers/courage_tracker.py
@@ -7,6 +7,7 @@ from app.config import config
 from app.consumers.courage_consumer import consume_courage_message
 from app.schemas.action import ActionJson
 from app.utils.gql import fetch_block_data, get_block_tip
+from app.utils.stage_cost import refresh_stage_sheets
 from shared.enums import PassType
 from shared.models.action import Block
 from shared.models.arena import BattleHistory
@@ -111,6 +112,7 @@ def track_courage_actions(planet_id: str, gql_url: str, block_index: int):
 
 
 def track_missing_blocks():
+    refresh_stage_sheets()
     for planet_id, gql_url in config.gql_url_map.items():
         if planet_id not in config.enabled_planets:
             continue

--- a/apps/tracker/app/utils/stage_cost.py
+++ b/apps/tracker/app/utils/stage_cost.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import time
 from typing import Dict, Optional
 
 import requests
@@ -10,21 +9,29 @@ from shared.enums import PlanetID
 logger = structlog.get_logger(__name__)
 
 DEFAULT_COST_AP = 5
-_CACHE_TTL = 3600  # 1 hour
 
 _stage_cost_cache: Dict[str, Dict[int, int]] = {}  # planet_id -> {stage_id -> cost_ap}
-_cache_timestamp: Dict[str, float] = {}  # planet_id -> last_fetched_time
+_etag_cache: Dict[str, str] = {}  # planet_id -> etag
 
 CDN_BASE_URL = "https://sheets.planetarium.dev"
 
 
-def _fetch_stage_sheet(planet_id: PlanetID) -> Dict[int, int]:
-    """Fetch StageSheet from R2 CDN and return stage_id -> cost_ap mapping."""
+def _fetch_stage_sheet(planet_id: PlanetID) -> Optional[Dict[int, int]]:
+    """Fetch StageSheet from R2 CDN if changed. Returns None when not modified."""
     planet_key = planet_id.decode()
     url = f"{CDN_BASE_URL}/{planet_key}/StageSheet.csv"
+    headers = {}
+    cached_etag = _etag_cache.get(planet_key)
+    if cached_etag:
+        headers["If-None-Match"] = cached_etag
     try:
-        resp = requests.get(url, timeout=10)
+        resp = requests.get(url, headers=headers, timeout=10)
+        if resp.status_code == 304:
+            return None
         resp.raise_for_status()
+        etag = resp.headers.get("ETag")
+        if etag:
+            _etag_cache[planet_key] = etag
         reader = csv.DictReader(io.StringIO(resp.text))
         result = {}
         for row in reader:
@@ -38,7 +45,7 @@ def _fetch_stage_sheet(planet_id: PlanetID) -> Dict[int, int]:
         return result
     except Exception as e:
         logger.warning(f"Failed to fetch StageSheet from CDN for {planet_key}: {e}")
-        return {}
+        return None
 
 
 def get_stage_cost_ap(planet_id: PlanetID, stage_id: Optional[int]) -> int:
@@ -47,16 +54,20 @@ def get_stage_cost_ap(planet_id: PlanetID, stage_id: Optional[int]) -> int:
         return DEFAULT_COST_AP
 
     planet_key = planet_id.decode()
-    now = time.time()
 
-    if (
-        planet_key not in _stage_cost_cache
-        or now - _cache_timestamp.get(planet_key, 0) > _CACHE_TTL
-    ):
+    if planet_key not in _stage_cost_cache:
         sheet = _fetch_stage_sheet(planet_id)
         if sheet:
             _stage_cost_cache[planet_key] = sheet
-            _cache_timestamp[planet_key] = now
 
     cost_ap = _stage_cost_cache.get(planet_key, {}).get(stage_id, DEFAULT_COST_AP)
     return cost_ap
+
+
+def refresh_stage_sheets():
+    """Re-fetch StageSheet for all cached planets if CDN content changed."""
+    for planet_key in list(_stage_cost_cache.keys()):
+        planet_id = PlanetID(planet_key.encode())
+        sheet = _fetch_stage_sheet(planet_id)
+        if sheet is not None:
+            _stage_cost_cache[planet_key] = sheet

--- a/apps/tracker/app/utils/stage_cost.py
+++ b/apps/tracker/app/utils/stage_cost.py
@@ -1,0 +1,62 @@
+import csv
+import io
+import time
+from typing import Dict, Optional
+
+import requests
+import structlog
+from shared.enums import PlanetID
+
+logger = structlog.get_logger(__name__)
+
+DEFAULT_COST_AP = 5
+_CACHE_TTL = 3600  # 1 hour
+
+_stage_cost_cache: Dict[str, Dict[int, int]] = {}  # planet_id -> {stage_id -> cost_ap}
+_cache_timestamp: Dict[str, float] = {}  # planet_id -> last_fetched_time
+
+CDN_BASE_URL = "https://sheets.planetarium.dev"
+
+
+def _fetch_stage_sheet(planet_id: PlanetID) -> Dict[int, int]:
+    """Fetch StageSheet from R2 CDN and return stage_id -> cost_ap mapping."""
+    planet_key = planet_id.decode()
+    url = f"{CDN_BASE_URL}/{planet_key}/StageSheet.csv"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        reader = csv.DictReader(io.StringIO(resp.text))
+        result = {}
+        for row in reader:
+            try:
+                result[int(row["id"])] = int(row["cost_ap"])
+            except (ValueError, KeyError):
+                continue
+        logger.info(
+            f"Fetched StageSheet from CDN: {len(result)} stages loaded for {planet_key}"
+        )
+        return result
+    except Exception as e:
+        logger.warning(f"Failed to fetch StageSheet from CDN for {planet_key}: {e}")
+        return {}
+
+
+def get_stage_cost_ap(planet_id: PlanetID, stage_id: Optional[int]) -> int:
+    """Get the CostAP for a given stage, using a cached StageSheet from CDN."""
+    if stage_id is None:
+        return DEFAULT_COST_AP
+
+    planet_key = planet_id.decode()
+    now = time.time()
+
+    if (
+        planet_key not in _stage_cost_cache
+        or now - _cache_timestamp.get(planet_key, 0) > _CACHE_TTL
+    ):
+        sheet = _fetch_stage_sheet(planet_id)
+        if sheet:
+            _stage_cost_cache[planet_key] = sheet
+            _cache_timestamp[planet_key] = now
+
+    cost_ap = _stage_cost_cache.get(planet_key, {}).get(stage_id, DEFAULT_COST_AP)
+    return cost_ap


### PR DESCRIPTION
## Summary

- 하드모드 스윕 시 용기경험치가 클라이언트 표시값의 2배로 계산되던 버그 수정
- `courage_consumer.py`의 `AP_PER_ADVENTURE = 5` 하드코딩이 원인
- 라이브 환경 하드모드 스테이지(451+)는 `PatchTableSheet`로 `cost_ap=10`으로 패치된 상태

## Changes

- `stage_cost.py` 신규: R2 CDN에서 StageSheet를 가져와 stage별 CostAP를 1시간 TTL로 캐싱
- `courage_tracker.py`: sweep 액션의 `stageId`를 action_data에 포함
- `courage_consumer.py`: 하드코딩된 `AP_PER_ADVENTURE=5` 대신 실제 CostAP 사용

## Root Cause

| | 클라이언트 | SeasonPass 서비스 (수정 전) |
|---|---|---|
| CostAP 참조 | `StageSheet[stageId].CostAP` = **10** | `AP_PER_ADVENTURE` = **5** (하드코딩) |
| 1 AP스톤 플레이 횟수 | 120 / 10 = **12회** | 120 / 5 = **24회** |
| 용기XP (base=10) | 10 × 12 = **120** | 10 × 24 = **240** (2배 과다) |

## Test plan

- [x] R2 CDN에서 StageSheet 정상 로드 확인 (531 stages)
- [x] 일반 스테이지 cost_ap=5, 하드모드 cost_ap=10 정확 구분 확인
- [x] 수정 후 server/client 플레이 횟수 일치 확인 (스테이킹 coef 100/80/60 모두)
- [x] 미존재 스테이지 → 기본값 5 fallback 확인
- [ ] 스테이징 환경 배포 후 실제 하드모드 스윕 경험치 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)