### PR TITLE
fix(api): short-circuit empty claims to prevent no-op DB writes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,10 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
-        args: [season_pass, tests]
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.0
+    rev: 5.13.2
     hooks:
       - id: isort
-        args: [season_pass, tests]
 -   repo: https://github.com/PyCQA/autoflake
     rev: v2.0.0
     hooks:

--- a/apps/api/app/api/user.py
+++ b/apps/api/app/api/user.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -328,7 +327,9 @@ def upgrade_season_pass(request: UpgradeRequestSchema, sess=Depends(session)):
 
             # Send task to Celery worker
             claim_message = ClaimMessage(uuid=claim.uuid)
-            task_id = send_to_worker("season_pass.process_claim", claim_message.model_dump())
+            task_id = send_to_worker(
+                "season_pass.process_claim", claim_message.model_dump()
+            )
             logging.debug(
                 f"Task for claim {claim.uuid} sent to Celery worker with task_id: {task_id}"
             )
@@ -432,10 +433,18 @@ def claim_reward(request: ClaimRequestSchema, sess=Depends(session)):
             f"No activity recorded for season {target_pass.id} for avatar {request.avatar_addr}"
         )
 
+    # Short-circuit no-op claims: nothing to reward means no Claim row and
+    # no worker dispatch are needed, so we can skip the row lock and commit.
+    available = user_season.available_rewards(sess)
+    if not available["normal"] and not available["premium"]:
+        return ClaimResultSchema(user=user_season, reward_list=[])
+
     inprogress_claim_count = sess.scalar(
         select(func.count()).where(
             Claim.reward_list != [],
-            or_(Claim.tx_status == TxStatus.STAGED, Claim.tx_status == TxStatus.INVALID),
+            or_(
+                Claim.tx_status == TxStatus.STAGED, Claim.tx_status == TxStatus.INVALID
+            ),
         )
     )
 
@@ -449,7 +458,9 @@ def claim_reward(request: ClaimRequestSchema, sess=Depends(session)):
 
         if claim.reward_list:
             claim_message = ClaimMessage(uuid=claim.uuid)
-            task_id = send_to_worker("season_pass.process_claim", claim_message.model_dump())
+            task_id = send_to_worker(
+                "season_pass.process_claim", claim_message.model_dump()
+            )
             logging.debug(
                 f"Task for claim {claim.uuid} sent to Celery worker with task_id: {task_id}"
             )
@@ -516,7 +527,9 @@ def claim_prev_reward(request: ClaimRequestSchema, sess=Depends(session)):
 
         if claim.reward_list:
             claim_message = ClaimMessage(uuid=claim.uuid)
-            task_id = send_to_worker("season_pass.process_claim", claim_message.model_dump())
+            task_id = send_to_worker(
+                "season_pass.process_claim", claim_message.model_dump()
+            )
             logging.debug(
                 f"Task for claim {claim.uuid} sent to Celery worker with task_id: {task_id}"
             )


### PR DESCRIPTION
## Summary
- `claim_reward` endpoint was creating empty `Claim` rows (~87% of recent traffic) when a bot/script kept re-polling already-claimed seasons. Each empty claim still grabbed a row lock + INSERT + commit + Celery dispatch attempt, exhausting the SQLAlchemy QueuePool (size 10 + overflow 20) under burst.
- Added an early return immediately after the `user_season` lookup when `available_rewards()` is empty in both `normal` and `premium`. Response shape is unchanged (`ClaimResultSchema(user, reward_list=[])`) so the game client sees the same payload.
- Fixed `.pre-commit-config.yaml` so hooks actually run: `black`/`isort` were pointing at a non-existent `season_pass` directory (layout moved under `apps/`), and isort 6.0.0 needed pre-commit framework >= 3.2 which isn't universally installed. Dropped the stale dir args (hooks now run only against staged files) and pinned isort to 5.13.2.

## Background

Production seasonpass-api was throwing `QueuePool limit of size 10 overflow 20 reached, connection timed out, timeout 60.00`. DB analysis showed:

```
1h total Claim rows created:          7,955
worker-processed (tx_status != NULL): 1,048  (13%)
empty reward, tx_status = NULL:       6,908  (87%)
```

The 87% empty-claim batch came almost entirely from a single OVH IP (`51.83.6.194`) farming 391 agent addresses with batched `current` + `claim` calls every 2 minutes. The empty path created a `Claim` row, committed, then skipped the `if claim.reward_list:` gate — so `tx_status` stayed NULL forever and the row was wasted state, but the cost of getting there (lock + INSERT + commit) starved the connection pool.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| user has rewards to claim | INSERT Claim + dispatch worker | (unchanged) |
| user already claimed everything | INSERT empty Claim row + return `reward_list=[]` | Early return `reward_list=[]`, no row inserted |
| user has no `UserSeasonPass` row | `SeasonNotFoundError` | (unchanged) |
| `force=True` with old/inactive season | empty claim, no worker | Early return (same response) |
| `inprogress_claim_count > 50` overload | `ServerOverloadError` | Same, but the empty-claim path no longer contributes to this count anyway |

The `with_for_update()` row lock is acquired before the early return; FastAPI's session dependency cleans up via `sess.close()` on the `finally`, releasing the lock cleanly without commit.

## Test plan
- [ ] Verify `/api/user/claim` still returns `ClaimResultSchema(user, reward_list=[<rewards>])` for users who have something to claim.
- [ ] Verify `/api/user/claim` returns `ClaimResultSchema(user, reward_list=[])` for already-claimed seasons (game client behavior unchanged).
- [ ] Verify no `Claim` row is inserted for the empty-claim path (`SELECT count(*) FROM claim WHERE tx_status IS NULL AND created_at > now()-interval '5m'` should stop growing in the bot-traffic scenario).
- [ ] Verify QueuePool exhaustion alarms cease.
- [ ] Verify `.pre-commit-config.yaml` runs cleanly locally with `pre-commit 2.21` and `pre-commit 3.x`.

## Follow-up (not in this PR)
- `claim_prev_reward` has the same shape and would benefit from the same short-circuit if bots ever pivot to it.
- Consider `joinedload(season_pass)` on the `user_season` SELECT to save one query on the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)