### PR TITLE
fix(db): partial index for unsettled claims (stop invalid-claim full-scan timeouts)

### DIFF
--- a/apps/shared/tool/migrations/versions/61d0dd969e60_add_partial_index_unsettled_claims.py
+++ b/apps/shared/tool/migrations/versions/61d0dd969e60_add_partial_index_unsettled_claims.py
@@ -1,0 +1,45 @@
+"""Add partial index for unsettled claims (invalid-claim / claim guard)
+
+Revision ID: 61d0dd969e60
+Revises: bca8f726a5ee
+Create Date: 2026-06-29 01:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "61d0dd969e60"
+down_revision: Union[str, None] = "bca8f726a5ee"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# NOTE: mainnet already has this index (created out-of-band via
+# CREATE INDEX CONCURRENTLY), so `if_not_exists` makes the migration a no-op
+# there. The `claim` table is ~1.7GB / 1M+ rows; on a large fresh database
+# prefer creating this CONCURRENTLY out-of-band first, then running the
+# migration (a plain CREATE INDEX takes a write lock for the build).
+INDEX_NAME = "idx_claim_unsettled"
+WHERE = "reward_list <> '[]' AND (tx_status <> 'SUCCESS' OR tx_status IS NULL)"
+
+
+def upgrade() -> None:
+    # Serves /api/invalid-claim and the claim-guard count in user.claim_reward.
+    # Without it those do a full seq scan of the whole claim table on every
+    # call, which balloons to a request timeout under load. The partial index
+    # only covers unsettled (non-SUCCESS, reward-bearing) claims, so it stays
+    # tiny and turns the scan into an index-only scan.
+    op.create_index(
+        INDEX_NAME,
+        "claim",
+        ["created_at"],
+        unique=False,
+        if_not_exists=True,
+        postgresql_where=sa.text(WHERE),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(INDEX_NAME, table_name="claim", if_exists=True)


### PR DESCRIPTION
## What
Backfill an alembic migration for the partial index `idx_claim_unsettled` on the `claim` table.

## Why
`/api/invalid-claim` and the claim guard in `user.claim_reward` filter:
```sql
WHERE reward_list <> '[]' AND (tx_status <> 'SUCCESS' OR tx_status IS NULL)
```
with **no supporting index**, so they **full seq-scan the ~1.7GB / 1M-row `claim` table on every call**:
- Assertible polls `/api/invalid-claim` every ~5 min.
- The guard runs on **every `POST /api/user/claim`**.

Under load / early-morning I/O contention these scans balloon to the **180s request timeout** → PagerDuty **Test Invalid Claim** / **Test Block Status** pages (block-status & check-nonce time out collaterally because the slow scans hold DB connections). This is the root cause of the recurring seasonpass alarms.

## Fix
A **partial** index covering only unsettled (non-SUCCESS, reward-bearing) rows → tiny index, **Index Only Scan** instead of a 1.7GB Seq Scan.

**Measured on mainnet** (index applied out-of-band via `CREATE INDEX CONCURRENTLY`):
| | before | after |
|---|---|---|
| invalid-claim/guard query | ~500ms (Seq Scan, idle) | **2–7ms (Index Only Scan)** |

## Apply notes
- **Already live on mainnet** (created via `CREATE INDEX CONCURRENTLY`), so `if_not_exists` makes this migration a **no-op there** — it just records the alembic version; it exists to keep code/DB in sync and to provision other environments (internal will actually create it).
- Single alembic head (`bca8f726a5ee`, = mainnet `alembic_version`); this chains onto it, so `alembic upgrade head` applies cleanly.
- Migrations are applied **manually** here (no init-container/Job/entrypoint runs alembic on deploy; CI only runs `alembic upgrade head` against a throwaway test DB).
- For a large fresh DB, prefer creating it `CONCURRENTLY` out-of-band first (a plain `CREATE INDEX` takes a build-time write lock).

## Follow-ups (separate)
- `statement_timeout` so any future slow query fails fast instead of hanging 180s.
- autovacuum tuning on `claim` / `user_season_pass` (under-vacuumed, bloating).
- Move GQL/worker-dispatch out of DB transactions (idle-in-transaction hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
