### PR TITLE
refactor(api): call cleared-stage RPC outside the DB transaction (fix lock pile-up)

### DIFF
--- a/apps/api/app/api/user.py
+++ b/apps/api/app/api/user.py
@@ -38,6 +38,26 @@ router = APIRouter(
 )
 
 
+def _fetch_cleared_stage(planet_id: PlanetID, avatar_addr: str) -> int:
+    """Fetch the avatar's last cleared stage from headless (GQL).
+
+    Deliberately takes NO DB session. Callers MUST release any open DB
+    transaction (sess.rollback()/commit()) before calling this. Holding a
+    pooled connection / row lock open across this network round-trip is what
+    caused idle-in-transaction lock pile-ups and DB pool exhaustion when the
+    RPC node was slow.
+    """
+    gql_client = GQLClient(
+        config.converted_gql_url_map,
+        config.jwt_secret,
+        timeout=config.gql_timeout,
+    )
+    _, cleared_stage = gql_client.get_last_cleared_stage(
+        planet_id, avatar_addr, timeout=1
+    )
+    return cleared_stage
+
+
 def get_default_usp(
     sess,
     planet_id: PlanetID,
@@ -48,24 +68,24 @@ def get_default_usp(
     try:
         match season_pass.pass_type:
             case PassType.WORLD_CLEAR_PASS:
-                gql_client = GQLClient(
-                    config.converted_gql_url_map,
-                    config.jwt_secret,
-                    timeout=config.gql_timeout,
-                )
-                _, cleared_stage = gql_client.get_last_cleared_stage(
-                    planet_id, avatar_addr, timeout=1
-                )
+                # Capture scalars, then release the read connection BEFORE the
+                # RPC call so we don't pin a pooled connection / hold a lock
+                # open across the (possibly slow) network round-trip.
+                season_pass_id = season_pass.id
+                pass_type = season_pass.pass_type
+                sess.rollback()
+
+                cleared_stage = _fetch_cleared_stage(planet_id, avatar_addr)
 
                 usp = UserSeasonPass(
                     planet_id=planet_id,
                     agent_addr=agent_addr,
                     avatar_addr=avatar_addr,
-                    season_pass=season_pass,
+                    season_pass_id=season_pass_id,
                     exp=cleared_stage,
                 )
                 if cleared_stage > 0:
-                    usp.level = get_level(sess, season_pass.pass_type, usp.exp)
+                    usp.level = get_level(sess, pass_type, usp.exp)
                 sess.add(usp)
                 sess.commit()
                 sess.refresh(usp)
@@ -128,16 +148,15 @@ def user_status(
         target = get_default_usp(sess, planet_id, agent_addr, avatar_addr, target_pass)
     elif pass_type == PassType.WORLD_CLEAR_PASS and target.exp == 0:
         # 0 cleared stage is usually not normal data.
-        gql_client = GQLClient(
-            config.converted_gql_url_map,
-            config.jwt_secret,
-            timeout=config.gql_timeout,
-        )
-        _, cleared_stage = gql_client.get_last_cleared_stage(
-            planet_id, target.avatar_addr, timeout=1
-        )
+        # Capture scalars, release the read connection, then call the RPC with
+        # no transaction held (see _fetch_cleared_stage).
+        avatar = target.avatar_addr
+        pass_type = target_pass.pass_type
+        sess.rollback()
+
+        cleared_stage = _fetch_cleared_stage(planet_id, avatar)
         target.exp = cleared_stage
-        target.level = get_level(sess, target_pass.pass_type, target.exp)
+        target.level = get_level(sess, pass_type, target.exp)
         sess.add(target)
         sess.commit()
 
@@ -172,16 +191,15 @@ def all_user_status(
             )
         elif pass_type == PassType.WORLD_CLEAR_PASS and target.exp == 0:
             # 0 cleared stage is usually not normal data.
-            gql_client = GQLClient(
-                config.converted_gql_url_map,
-                config.jwt_secret,
-                timeout=config.gql_timeout,
-            )
-            _, cleared_stage = gql_client.get_last_cleared_stage(
-                planet_id, target.avatar_addr, timeout=1
-            )
+            # Capture scalars, release the read connection, then call the RPC
+            # with no transaction held (see _fetch_cleared_stage).
+            avatar = target.avatar_addr
+            pass_type = target_pass.pass_type
+            sess.rollback()
+
+            cleared_stage = _fetch_cleared_stage(planet_id, avatar)
             target.exp = cleared_stage
-            target.level = get_level(sess, target_pass.pass_type, target.exp)
+            target.level = get_level(sess, pass_type, target.exp)
             sess.add(target)
             sess.commit()
 


### PR DESCRIPTION
> **DRAFT — needs validation before merge.** Money/data path; changes session/transaction semantics. Run the api test suite + soak on internal before mainnet.
> **Stacked on #306** (base = `fix/api-ping-async-resilience`). Re-target to `main` after #306 merges.

## Root cause (caught live on mainnet)
A request held its DB transaction — and a `user_season_pass` row lock — open **across the `get_last_cleared_stage` RPC call**. When the RPC node was slow, the pooled connection + row lock were pinned; 20+ `POST /api/user/claim` requests blocked on the lock (`SELECT ... FOR UPDATE`) for **>150s**, exhausting the **30/30** pool. Every DB endpoint (block-status / invalid-claim / claim) then timed out → PagerDuty `Test Invalid Claim` / `Test Block Status` pages.

`pg_stat_activity` during the incident: 21 `active` backends all `wait_event=Lock` on `user_season_pass`, 16 `idle in transaction` (ClientRead) holding for up to ~890s.

## Change
Extract the GQL call into `_fetch_cleared_stage()` (takes **no DB session**) and at the three call sites:
- `get_default_usp` (WORLD_CLEAR_PASS)
- `user_status` exp==0 refetch
- `all_user_status` exp==0 refetch

capture the needed scalars, `sess.rollback()` to **release the pooled connection before** the network round-trip, then do the write in a fresh transaction. No connection/lock is held across the RPC anymore.

## Behavior change / risk
- `sess.rollback()` mid-request **expires** ORM objects already loaded (e.g. items appended to the `all_user_status` response list); they **reload on attribute access** during serialization → correct results, a few extra SELECTs.
- `get_default_usp` now sets `season_pass_id=` instead of the `season_pass=` relationship (avoids depending on the expired object).
- There are **no existing unit tests** for these handlers → validation is manual/CI-added.

## Validation checklist (before merge)
- [ ] `status/all` & `status` for: existing user, brand-new user (WorldClear + Courage/AdvBoss), WorldClear with exp==0 (refetch path).
- [ ] Response (`UserSeasonPassSchema`) serializes correctly after the rollback/reload.
- [ ] Concurrent claims for the same avatar no longer pile up on the lock during a slow RPC (soak on internal).
- [ ] No regression in `claim` flow.

## Companion changes
- #306: async `/ping`, `pool_timeout` 10s, thread cap 25, **DB pool 30→60**.
- Role-level (DB): `idle_in_transaction_session_timeout=60s`, `lock_timeout=10s`, `statement_timeout=30s` (immediate prevention; applied out-of-band).
- claim partial index (#307).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
