### PR TITLE
refactor(tracker): run tx-tracker GQL outside the DB transaction

### DIFF
--- a/apps/tracker/app/trackers/tx_tracker.py
+++ b/apps/tracker/app/trackers/tx_tracker.py
@@ -1,18 +1,16 @@
 import concurrent.futures
 import json
-import os
 from collections import defaultdict
 from typing import Optional, Tuple
 
 import structlog
+from app.config import config
 from gql.dsl import DSLQuery, dsl_gql
 from shared.enums import PlanetID, TxStatus
 from shared.models.user import Claim
 from shared.utils._graphql import GQLClient
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, update
 from sqlalchemy.orm import scoped_session, sessionmaker
-
-from app.config import config
 
 logger = structlog.get_logger(__name__)
 
@@ -67,51 +65,84 @@ def process(
 
 def track_tx():
     logger.info("Tracking unfinished transactions")
-    sess = scoped_session(sessionmaker(bind=engine))
-    claim_list = sess.scalars(
-        select(Claim)
-        .where(
-            Claim.tx_status.in_(
-                (
-                    TxStatus.STAGED,
-                    TxStatus.INVALID,
+
+    # Read the unsettled claims in a short transaction, then release the
+    # connection *before* the per-tx headless calls below. Previously this one
+    # session stayed open across the whole GQL batch, so when a node was slow it
+    # sat idle-in-transaction for minutes (observed 448s). That pinned the xmin
+    # horizon and blocked autovacuum on claim/user_season_pass (dead tuples piled
+    # up). Capture just the scalars we need, then close the session so the RPC
+    # batch runs untethered to any DB transaction.
+    read_sess = scoped_session(sessionmaker(bind=engine))
+    try:
+        claim_list = read_sess.scalars(
+            select(Claim)
+            .where(
+                Claim.tx_status.in_(
+                    (
+                        TxStatus.STAGED,
+                        TxStatus.INVALID,
+                    )
                 )
             )
-        )
-        .order_by(Claim.id)
-        .limit(BLOCK_LIMIT)
-    ).fetchall()
-    result = defaultdict(list)
+            .order_by(Claim.id)
+            .limit(BLOCK_LIMIT)
+        ).fetchall()
+        targets = [
+            (claim.id, PlanetID(claim.planet_id), claim.tx_id) for claim in claim_list
+        ]
+    finally:
+        read_sess.close()
 
-    if not claim_list:
+    if not targets:
         logger.info("No transactions to track", tracker="tx_tracker")
         return
 
+    # Query headless for each tx with no DB transaction held open.
+    result = defaultdict(list)
+    updates = []  # (claim_id, tx_id, new_status)
     futures = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        for claim in claim_list:
-            futures[executor.submit(process, PlanetID(claim.planet_id), claim.tx_id)] = (
-                claim
-            )
+        for claim_id, planet_id, tx_id in targets:
+            futures[executor.submit(process, planet_id, tx_id)] = claim_id
 
         for future in concurrent.futures.as_completed(futures):
             tx_id, tx_status, msg = future.result()
-            target_claim = futures[future]
+            claim_id = futures[future]
             result[tx_status.name].append(tx_id)
-            target_claim.tx_status = tx_status
+            updates.append((claim_id, tx_id, tx_status))
             # if msg:
             #     claim.msg = "\n".join([claim.msg, msg])
-            sess.add(target_claim)
 
     logger.info(
         "Transactions found to track",
         tracker="tx_tracker",
-        count=len(claim_list),
-        start_id=claim_list[0].id,
-        end_id=claim_list[-1].id,
+        count=len(targets),
+        start_id=targets[0][0],
+        end_id=targets[-1][0],
     )
-    sess.commit()
-    sess.close()
+
+    # Persist the resolved statuses in a fresh, short write transaction. The
+    # read->write gap is wider now that the GQL batch runs outside the
+    # transaction, so guard the write: match on tx_id (skip a claim re-staged
+    # with a new tx in between) AND require the row still be STAGED/INVALID (skip
+    # one already finalized to SUCCESS/FAILURE by another path), so we never
+    # clobber a settled status with a stale GQL result.
+    write_sess = scoped_session(sessionmaker(bind=engine))
+    try:
+        for claim_id, tx_id, tx_status in updates:
+            write_sess.execute(
+                update(Claim)
+                .where(
+                    Claim.id == claim_id,
+                    Claim.tx_id == tx_id,
+                    Claim.tx_status.in_((TxStatus.STAGED, TxStatus.INVALID)),
+                )
+                .values(tx_status=tx_status)
+            )
+        write_sess.commit()
+    finally:
+        write_sess.close()
 
     for status, tx_list in result.items():
         if status is None:


### PR DESCRIPTION
## What

`track_tx()` opened a session, `SELECT`ed up to 200 unsettled claims (`tx_status IN (STAGED, INVALID)`), then **held that transaction open** while it fanned out a per-claim headless GQL batch (`process()`), committing only at the very end. This splits it into three phases so no transaction is held across the RPC:

1. **Read** the unsettled claims in a short transaction, capture `(id, planet_id, tx_id)` as plain scalars, and `close()` the session before any RPC.
2. **GQL batch** with no DB transaction held open.
3. **Write** the resolved statuses in a fresh, short transaction.

## Why

Found while investigating the mainnet seasonpass DB after the #308 deploy. Live `pg_stat_activity` showed this exact query sitting **idle-in-transaction for 448s**:

```
SELECT claim.* FROM claim WHERE tx_status IN ('STAGED','INVALID') ORDER BY claim.id LIMIT 200
```

It's a plain `SELECT` (`AccessShareLock`, no `FOR UPDATE`), so it blocked no other query and caused **no alarms** — but the long-lived transaction **pinned the xmin horizon and blocked autovacuum** on the hot tables:

- `user_season_pass` — `last_autovacuum = None` (never autovacuumed), ~292k dead tuples
- `claim` — not vacuumed since the prior manual run, ~175k dead tuples

This is the **same anti-pattern the API status paths fixed in #308**, just living in the tracker (which #308 didn't touch). The tracker runs `track_tx()` on a 10s loop, so the xmin pin recurs continuously whenever a node is slow.

## Correctness notes

- The write now guards on **`tx_id` as well as `id`**: `UPDATE claim SET tx_status=... WHERE id=:id AND tx_id=:tx_id`. Decoupling the read from the write widens the read→write gap, so a claim that was re-staged with a new tx in between is now left untouched (picked up next cycle) instead of being clobbered with a stale status. `process()` returns the same `tx_id` it was given, so this is exactly the tx we resolved.
- `start_id`/`end_id`/`count` logging and the `STAGED`/`INVALID` selection are unchanged.
- The per-claim `process()` semantics, planet conversion (`PlanetID(...)`), and thread pool (`max_workers=10`) are unchanged.
- Also drops a dead `import os`.

## Testing

The tracker has no existing test suite and the models use postgres-only types (`ARRAY`/`ENUM`/`JSONB`), so an in-memory harness is disproportionate here. Verified via `py_compile` + black/isort/autoflake (pre-commit). A tracker test harness is a reasonable follow-up. Behavior is otherwise a straight restructuring of the existing read→GQL→write flow.

Independent of #306/#308 (touches `apps/tracker` only) — targets `main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)