### PR TITLE
fix(api): resolve level before mutating target in status backfill (drop early row lock)

### DIFF
--- a/apps/api/app/api/user.py
+++ b/apps/api/app/api/user.py
@@ -155,8 +155,15 @@ def user_status(
         sess.rollback()
 
         cleared_stage = _fetch_cleared_stage(planet_id, avatar)
+        # Resolve the level BEFORE mutating `target`. get_level() runs a SELECT,
+        # and if `target` were already dirty the SELECT would autoflush it as an
+        # UPDATE user_season_pass -- taking the row lock for the whole rest of the
+        # block (and, under load, holding it while the connection sits idle).
+        # Computing the level first means the only write is the single UPDATE at
+        # commit, so the row lock is held for that flush alone.
+        level = get_level(sess, pass_type, cleared_stage)
         target.exp = cleared_stage
-        target.level = get_level(sess, pass_type, target.exp)
+        target.level = level
         sess.add(target)
         sess.commit()
 
@@ -198,8 +205,13 @@ def all_user_status(
             sess.rollback()
 
             cleared_stage = _fetch_cleared_stage(planet_id, avatar)
+            # Resolve the level BEFORE mutating `target` so get_level()'s SELECT
+            # doesn't autoflush a dirtied `target` into an early UPDATE that holds
+            # the user_season_pass row lock across the rest of the block. See the
+            # matching note in user_status().
+            level = get_level(sess, pass_type, cleared_stage)
             target.exp = cleared_stage
-            target.level = get_level(sess, pass_type, target.exp)
+            target.level = level
             sess.add(target)
             sess.commit()
 

--- a/apps/api/tests/test_user_status.py
+++ b/apps/api/tests/test_user_status.py
@@ -1,0 +1,193 @@
+"""Regression tests for the WorldClearPass exp/level backfill on the status
+endpoints (`/api/user/status`, `/api/user/status/all`).
+
+These guard the behaviour of the on-read backfill after it was reordered so the
+`get_level()` SELECT runs *before* `target` is mutated (so SQLAlchemy autoflush
+no longer takes the user_season_pass row lock across the rest of the block). The
+reorder is behaviour-preserving; these tests pin that behaviour: a zero-exp
+WorldClear row is backfilled to the RPC-reported cleared stage, the level is
+derived from the level table, the value is persisted, and a non-zero row is left
+untouched (and does not hit the RPC).
+"""
+from datetime import datetime, timedelta, timezone
+
+from shared.enums import PassType, PlanetID
+from shared.models.season_pass import Level
+from shared.models.user import SeasonPass, UserSeasonPass
+
+ODIN = "0x000000000000"
+AGENT = "0xabc0000000000000000000000000000000000001"
+AVATAR = "0xabc0000000000000000000000000000000000002"
+
+
+def _seed_worldclear(test_session, *, exp=0, level=0, season_index=1):
+    season = SeasonPass(
+        pass_type=PassType.WORLD_CLEAR_PASS,
+        season_index=season_index,
+        start_timestamp=datetime.now(tz=timezone.utc) - timedelta(days=1),
+        end_timestamp=datetime.now(tz=timezone.utc) + timedelta(days=1),
+        instant_exp=0,
+        reward_list=[],
+    )
+    test_session.add(season)
+    test_session.flush()
+
+    # level thresholds: exp>=10 -> L1, >=20 -> L2, >=30 -> L3
+    for lv, threshold in ((1, 10), (2, 20), (3, 30)):
+        test_session.add(
+            Level(pass_type=PassType.WORLD_CLEAR_PASS, level=lv, exp=threshold)
+        )
+
+    usp = UserSeasonPass(
+        planet_id=PlanetID.ODIN,
+        agent_addr=AGENT,
+        avatar_addr=AVATAR,
+        season_pass_id=season.id,
+        exp=exp,
+        level=level,
+    )
+    test_session.add(usp)
+    test_session.commit()
+    return season, usp
+
+
+def _reload_usp(test_session, season_id):
+    test_session.expire_all()
+    return (
+        test_session.query(UserSeasonPass)
+        .filter(
+            UserSeasonPass.season_pass_id == season_id,
+            UserSeasonPass.avatar_addr == AVATAR,
+        )
+        .one()
+    )
+
+
+def test_status_worldclear_backfills_exp_and_level_when_zero(
+    client, test_session, monkeypatch
+):
+    season, _ = _seed_worldclear(test_session, exp=0, level=0)
+
+    calls = []
+
+    def fake_fetch(planet_id, avatar_addr):
+        calls.append((planet_id, avatar_addr))
+        return 25  # cleared stage; with the seeded levels this maps to L2
+
+    monkeypatch.setattr("app.api.user._fetch_cleared_stage", fake_fetch)
+
+    resp = client.get(
+        "/api/user/status",
+        params={
+            "planet_id": ODIN,
+            "agent_addr": AGENT,
+            "avatar_addr": AVATAR,
+            "pass_type": PassType.WORLD_CLEAR_PASS.value,
+            "season_index": season.season_index,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["exp"] == 25
+    assert body["level"] == 2
+    assert len(calls) == 1  # RPC hit exactly once
+
+    persisted = _reload_usp(test_session, season.id)
+    assert persisted.exp == 25
+    assert persisted.level == 2
+
+
+def test_status_worldclear_no_backfill_when_exp_nonzero(
+    client, test_session, monkeypatch
+):
+    season, _ = _seed_worldclear(test_session, exp=15, level=1)
+
+    calls = []
+    monkeypatch.setattr(
+        "app.api.user._fetch_cleared_stage",
+        lambda planet_id, avatar_addr: calls.append(1) or 999,
+    )
+
+    resp = client.get(
+        "/api/user/status",
+        params={
+            "planet_id": ODIN,
+            "agent_addr": AGENT,
+            "avatar_addr": AVATAR,
+            "pass_type": PassType.WORLD_CLEAR_PASS.value,
+            "season_index": season.season_index,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["exp"] == 15  # untouched
+    assert body["level"] == 1
+    assert calls == []  # RPC must NOT be called when exp != 0
+
+    persisted = _reload_usp(test_session, season.id)
+    assert persisted.exp == 15
+    assert persisted.level == 1
+
+
+def test_status_worldclear_cleared_stage_zero_stays_zero(
+    client, test_session, monkeypatch
+):
+    season, _ = _seed_worldclear(test_session, exp=0, level=0)
+
+    monkeypatch.setattr(
+        "app.api.user._fetch_cleared_stage", lambda planet_id, avatar_addr: 0
+    )
+
+    resp = client.get(
+        "/api/user/status",
+        params={
+            "planet_id": ODIN,
+            "agent_addr": AGENT,
+            "avatar_addr": AVATAR,
+            "pass_type": PassType.WORLD_CLEAR_PASS.value,
+            "season_index": season.season_index,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["exp"] == 0
+    assert body["level"] == 0
+
+    persisted = _reload_usp(test_session, season.id)
+    assert persisted.exp == 0
+    assert persisted.level == 0
+
+
+def test_status_all_worldclear_backfills_exp_and_level(
+    client, test_session, monkeypatch
+):
+    season, _ = _seed_worldclear(test_session, exp=0, level=0)
+
+    calls = []
+
+    def fake_fetch(planet_id, avatar_addr):
+        calls.append((planet_id, avatar_addr))
+        return 30  # maps to L3
+
+    monkeypatch.setattr("app.api.user._fetch_cleared_stage", fake_fetch)
+
+    resp = client.get(
+        "/api/user/status/all",
+        params={"planet_id": ODIN, "agent_addr": AGENT, "avatar_addr": AVATAR},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    wc = next(
+        item for item in body if item["season_pass"]["pass_type"] == "WorldClearPass"
+    )
+    assert wc["exp"] == 30
+    assert wc["level"] == 3
+    assert len(calls) == 1
+
+    persisted = _reload_usp(test_session, season.id)
+    assert persisted.exp == 30
+    assert persisted.level == 3


### PR DESCRIPTION
## What

The WorldClearPass on-read backfill in `user_status()` / `all_user_status()` did:

```python
target.exp = cleared_stage
target.level = get_level(sess, pass_type, target.exp)   # SELECT
sess.add(target); sess.commit()
```

Because `target` was already dirty, `get_level()`'s SELECT **autoflushed it as an `UPDATE user_season_pass`** — taking the row's exclusive lock *before* the SELECT and holding it through commit.

This reorders so the level is resolved from `cleared_stage` **before** `target` is mutated:

```python
level = get_level(sess, pass_type, cleared_stage)   # nothing dirty -> no autoflush UPDATE
target.exp = cleared_stage
target.level = level
sess.add(target); sess.commit()                     # single UPDATE here; row lock held only for the flush
```

## Why

Caught live on mainnet (`pg_stat_activity`): under concurrent polling of the same popular avatars, the early row lock from these backfills — together with `claim`'s `SELECT ... FOR UPDATE` on the same `user_season_pass` rows — formed a lock convoy. With no `lock_timeout` the waiters piled up (observed 1000s+), pinned the API pool, and timed out every DB endpoint → **block-status / invalid-claim** alarms.

`#308` had already moved the RPC out of the transaction; this removes the *other* half — the autoflush UPDATE that held the row lock across the rest of the block.

## Behaviour preserved

`get_level(cleared_stage) == get_level(target.exp)` because `target.exp` is set to `cleared_stage`. The persisted `exp`/`level` and the HTTP response are identical — this is a reorder, not a semantic change. Confirmed: the backfill still repairs zero-exp rows (which `available_rewards` / claim depend on), so claims are unaffected.

## Tests

Adds `tests/test_user_status.py` (the status endpoints had **no** coverage):
- zero-exp WorldClear → backfilled to the RPC cleared stage, level derived from the level table, **persisted**
- non-zero row → left untouched **and skips the RPC**
- `cleared_stage == 0` → stays zero (no error)
- same via `/status/all`

`_fetch_cleared_stage` is monkeypatched; runs against the existing local-postgres harness. 4 pass; the only suite failures are the pre-existing `test_burn_asset_*` (local Celery/redis backend unavailable), confirmed failing identically on the base branch.

## Stacking

Stacked on #309 (`yang/tx-tracker-gql-outside-txn`) → contains #306+#308+#309, so building this branch yields one image with everything. Merge order to main: #306 → #308 → #309 → this.

Note: complements the live `ALTER ROLE` timeouts (`lock_timeout=10s` / `idle_in_transaction_session_timeout=60s` / `statement_timeout=30s`) already applied as the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)