### PR TITLE
feat(api): make /invalid-claim return a stuck-claim count instead of 503-if-any

### DIFF
--- a/apps/api/app/api/__init__.py
+++ b/apps/api/app/api/__init__.py
@@ -2,8 +2,6 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 import requests
-from app.config import config
-from app.dependencies import session
 from fastapi import APIRouter, Depends
 from shared.constants import SEASONPASS_ADDRESS
 from shared.enums import PassType, PlanetID, TxStatus
@@ -13,6 +11,9 @@ from shared.utils.season_pass import create_jwt_token
 from sqlalchemy import desc, func, or_, select
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
+
+from app.config import config
+from app.dependencies import session
 
 from . import admin, season_pass, tmp, user
 
@@ -144,22 +145,29 @@ def block_status(sess=Depends(session)):
     return JSONResponse(status_code=503 if err else 200, content=result)
 
 
-@router.get("/invalid-claim")
+@router.get("/invalid-claim", response_model=int)
 def invalid_claim(sess: Session = Depends(session)):
+    """Number of claims stuck unsettled: older than 5 minutes, with rewards, and
+    not yet SUCCESS.
+
+    Returns a COUNT (always HTTP 200) rather than 503-if-any, so the alert
+    threshold lives in the monitor (mirrors IAP /purchase/invalid-receipt-count).
+    A single transient slow-settling tx therefore no longer pages on its own.
+
+    NOTE: the Assertible "Test Invalid Claim" check must assert on this number
+    (fail when it exceeds the threshold). Otherwise the check always sees 200 and
+    never alarms.
+    """
     now = datetime.now(tz=timezone.utc)
-    invalid_claim_list = sess.scalars(
-        select(Claim).where(
+    return sess.scalar(
+        select(func.count())
+        .select_from(Claim)
+        .where(
             Claim.created_at <= now - timedelta(minutes=5),
             Claim.reward_list != [],
             or_(Claim.tx_status != TxStatus.SUCCESS, Claim.tx_status.is_(None)),
         )
-    ).fetchall()
-    if invalid_claim_list:
-        return JSONResponse(
-            status_code=503,
-            content=f"{len(invalid_claim_list)} of invalid claims found.",
-        )
-    return JSONResponse(status_code=200, content="No invalid claims found.")
+    )
 
 
 @router.get("/failure-claim")

--- a/apps/api/tests/test_invalid_claim.py
+++ b/apps/api/tests/test_invalid_claim.py
@@ -1,0 +1,58 @@
+"""Regression tests for /api/invalid-claim after it was switched from
+"503 if any" to returning the COUNT of stuck claims (mirrors IAP
+/purchase/invalid-receipt-count). The alert threshold now lives in the monitor;
+the endpoint just reports the number so a single transient slow tx doesn't page.
+
+A claim counts as stuck when it is older than 5 minutes, has rewards, and has
+not reached SUCCESS (STAGED / INVALID / FAILURE / NULL).
+"""
+from datetime import datetime, timedelta, timezone
+
+from shared.enums import PlanetID, TxStatus
+from shared.models.user import Claim
+
+AGENT = "0xc1a10000000000000000000000000000000000a1"
+AVATAR = "0xc1a10000000000000000000000000000000000a2"
+REWARD = [{"ticker": "CRYSTAL", "amount": 1, "decimal_places": 0}]
+
+
+def _claim(test_session, uuid, *, age_min, tx_status, reward=REWARD):
+    test_session.add(
+        Claim(
+            uuid=uuid,
+            agent_addr=AGENT,
+            avatar_addr=AVATAR,
+            planet_id=PlanetID.ODIN,
+            reward_list=reward,
+            tx_status=tx_status,
+            created_at=datetime.now(tz=timezone.utc) - timedelta(minutes=age_min),
+        )
+    )
+
+
+def test_invalid_claim_returns_zero_when_none_stuck(client, test_session):
+    _claim(test_session, "ok1", age_min=10, tx_status=TxStatus.SUCCESS)
+    _claim(test_session, "ok2", age_min=1, tx_status=TxStatus.STAGED)  # too recent
+    test_session.commit()
+
+    resp = client.get("/api/invalid-claim")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == 0
+
+
+def test_invalid_claim_returns_count_of_stuck(client, test_session):
+    # counted: >5min old, has rewards, not SUCCESS
+    _claim(test_session, "staged_old", age_min=10, tx_status=TxStatus.STAGED)
+    _claim(test_session, "invalid_old", age_min=10, tx_status=TxStatus.INVALID)
+    _claim(test_session, "null_old", age_min=10, tx_status=None)
+    # NOT counted:
+    _claim(test_session, "success_old", age_min=10, tx_status=TxStatus.SUCCESS)
+    _claim(test_session, "staged_recent", age_min=1, tx_status=TxStatus.STAGED)
+    _claim(
+        test_session, "noreward_old", age_min=10, tx_status=TxStatus.STAGED, reward=[]
+    )
+    test_session.commit()
+
+    resp = client.get("/api/invalid-claim")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == 3  # staged_old + invalid_old + null_old


### PR DESCRIPTION
## What

`/invalid-claim` returned **HTTP 503 the moment a single claim** was stuck (>5min old, has rewards, not SUCCESS). This switches it to return the **count** (HTTP 200), mirroring IAP's `/purchase/invalid-receipt-count` — the alert threshold moves to the monitor.

```python
@router.get("/invalid-claim", response_model=int)
def invalid_claim(sess=Depends(session)):
    return sess.scalar(select(func.count()).select_from(Claim).where(... same filter ...))
```

The WHERE clause is unchanged (still served by the `idx_claim_unsettled` partial index). Only the response contract changes: `int` count instead of `503`/string.

## Why

Forensics on the most recent occurrence (06-29 23:25 KST): the only stuck claim was **one heimdall tx that took ~13min to settle then succeeded on its own** — a transient, self-healing chain delay. With the old `if any → 503` it raised a high-urgency page anyway. IAP already avoids this by reporting a count and thresholding in the monitor; this aligns SeasonPass with that.

A single transient slow tx no longer pages; a real stall (e.g. a nonce gap that stops all claims) still piles up past the threshold within minutes.

## ⚠️ Monitor coordination required (breaking for the check)

The Assertible **"Test Invalid Claim"** check currently keys on the 503. After this deploy the endpoint always returns 200, so the check must be reconfigured to **assert on the returned number** (fail when it exceeds the threshold, suggested start **≥3**, tune from data / match IAP's threshold). **Until that assertion is in place the check always passes and never alarms** — so update Assertible together with this deploy.

## Tests

`tests/test_invalid_claim.py`: returns `0` when nothing is stuck; returns the exact count (excludes SUCCESS, <5min-old, and reward-less claims). Full api suite green except the pre-existing `test_burn_asset_*` (local Celery/redis unavailable).

## Stacking

Stacked on #310 (`yang/status-backfill-lock-reorder`) → carries #306+#308+#309+#310+this, so one image has everything. Merge order to main: #306 → #308 → #309 → #310 → this.

Note: `/failure-claim` still uses the old 503-if-any pattern — left as-is (out of scope); could get the same treatment later if it's also noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)